### PR TITLE
feat: add scenario validation endpoint and tests

### DIFF
--- a/backend/tests/test_api_validate_scenario.py
+++ b/backend/tests/test_api_validate_scenario.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import json
+
+from fastapi.testclient import TestClient
+
+from chatagent.app import app
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def load_json(name: str) -> dict:
+    return json.loads((DATA_DIR / name).read_text())
+
+
+def test_validate_scenario_valid() -> None:
+    payload = load_json("scenario_example.json")
+    with TestClient(app) as client:
+        response = client.post("/api/validate-scenario", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "errors": []}
+
+
+def test_validate_scenario_invalid() -> None:
+    payload = load_json("scenario_invalid.json")
+    with TestClient(app) as client:
+        response = client.post("/api/validate-scenario", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert any(err["path"] == "events.0.timestamp" for err in body["errors"])


### PR DESCRIPTION
## Summary
- add POST `/api/validate-scenario` endpoint returning `{ok, errors}`
- expose reusable scenario validation helper
- test scenario validation API with valid and invalid samples

## Testing
- `pytest tests/test_api_validate_scenario.py -q`
- `pytest -q` *(fails: sqlite3.OperationalError attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68a121d5f74c83338b8965356ba877c0