### PR TITLE
docs: scaffold MkDocs documentation

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,18 @@
+name: docs-deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 backend/.env
 backend/.venv/
+site/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 Work is at an early stage; see [Roadmap v0.1](../../issues/1) for planned improvements and current progress.
 
+## Documentation
+
+See [the docs](docs/quickstart.md) for more details.
+
 ## Quickstart
 
 ```bash

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,13 @@
+# REPORT
+
+## Summary
+
+- Selected MkDocs with Material theme because the repository is primarily Python (35 Python files vs 1 JS/TS file).
+- Added documentation skeleton with Quickstart, Architecture, Contributing, and Changelog pages.
+- Configured docs-deploy GitHub Actions workflow to build the documentation using mkdocs-material.
+- Linked the README to the new documentation.
+
+## Follow-up
+
+- Expand each documentation page with detailed content.
+- Enable automatic publishing to GitHub Pages.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+An overview of ChatAgent components and data flow.
+
+For a detailed description see [ARCHITECTURE.md](../ARCHITECTURE.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Document project changes over time.
+
+## [Unreleased]
+
+- Initial documentation skeleton.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,7 @@
+# Contributing
+
+Guidelines for contributing to ChatAgent.
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/).
+- Keep pull requests focused and short.
+- Ensure tests and linters pass before merging.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart
+
+Instructions for getting started with ChatAgent.
+
+1. Install the backend:
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+2. Provide credentials and run:
+
+```bash
+echo 'CHATAGENT_GOOGLE_API_KEY=YOUR_KEY' > .env
+chatagent serve
+```
+
+This page is a placeholder for a more detailed guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: ChatAgent
+theme:
+  name: material
+nav:
+  - Quickstart: quickstart.md
+  - Architecture: architecture.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md
+  - Project Vision: project-vision.md
+  - System Prompt (inner): system-prompt-inner.md
+  - System Prompt (outer): system-prompt-outer.md


### PR DESCRIPTION
## Summary
- scaffold MkDocs Material documentation with Quickstart, Architecture, Contributing, and Changelog pages
- add docs-deploy workflow to build the documentation
- link README to the new docs and add REPORT

## Motivation
Provide a place for growing project documentation with automated builds.

Closes #1

## Checklist
- [x] /docs/ skeleton with key pages
- [x] GitHub Pages build workflow
- [x] README links to docs
- [x] REPORT with decision summary
- [ ] Tests adjusted or added (n/a)


------
https://chatgpt.com/codex/tasks/task_e_68a127c167308333b017dcc9baf0ac2a