### PR TITLE
docs: define domain model and module boundaries

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -42,3 +42,6 @@
 - `pytest` (fails: missing dependencies during collection)
 
 
+## Domain and Module Boundaries
+- Added `docs/DOMAIN.md` detailing core entities and relationships.
+- Drafted RFC `docs/rfcs/0001-module-boundaries.md` proposing incremental refactor steps toward a modular layout.

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -1,0 +1,50 @@
+# Domain Model
+
+This document outlines the core entities of the chat simulator and how they interact.
+
+## Entities
+
+### Conversation
+- Orchestrates message exchange between Agents.
+- Uses the active Scenario to seed initial context.
+- Persists progress through Memory and exposes transcripts for evaluation.
+
+### Agent
+- An autonomous actor participating in a Conversation.
+- Invokes Tools to perform actions.
+- Maintains its own Memory of prior exchanges.
+
+### Tool
+- External capability that can be invoked by an Agent.
+- Examples: shell commands, git operations, LLM calls.
+
+### Scenario
+- Describes initial world state and scheduled events.
+- Provides the starting configuration for a Conversation.
+
+### Memory
+- Stores conversation state for each Agent.
+- Supports retrieval of past exchanges during simulation.
+
+### Evaluator
+- Consumes Conversation outputs and Memories.
+- Produces metrics or feedback about the simulation.
+
+## Relationships and Boundaries
+
+- A **Scenario** spawns a **Conversation** with participating **Agents**.
+- **Agents** call **Tools** and update their **Memory** as the Conversation progresses.
+- The **Evaluator** reads the Conversation transcript and Memory snapshots to score outcomes.
+- Tools, storage, and user interfaces are treated as external adapters; the domain core remains framework‑agnostic.
+
+## Target Modular Structure
+
+| Module    | Responsibility                     | Existing code to migrate |
+|-----------|------------------------------------|--------------------------|
+| `core/`   | Entities and simulation logic      | `backend/app/models`, `backend/chatagent/agents`, `backend/chatagent/tools` (interfaces) |
+| `adapters/` | Implementations of external services (LLMs, shell, git, etc.) | `backend/chatagent/providers`, `backend/chatagent/tools` (implementations) |
+| `storage/` | Persistence and database access    | `backend/chatagent/db`, `backend/chatagent/services/persistence.py` |
+| `cli/`    | Command‑line entry points          | `backend/chatagent/cli.py` |
+| `web/`    | FastAPI app and static assets      | `backend/chatagent/app.py`, `backend/app/templates`, `backend/app/static`, `backend/chatagent/web` |
+
+This layout separates the domain core from frameworks and I/O, enabling independent evolution of adapters and interfaces.

--- a/docs/rfcs/0001-module-boundaries.md
+++ b/docs/rfcs/0001-module-boundaries.md
@@ -1,0 +1,50 @@
+# RFC 0001: Module boundaries
+
+- Status: Draft
+- Authors: ChatGPT
+- Created: 2024-05-??
+
+## Summary
+
+Define clear module boundaries for the chat simulator and outline small refactor steps to reach the target layout.
+
+## Motivation
+
+Current code mixes domain logic with framework and infrastructure details. Establishing modules will reduce coupling and enable parallel development.
+
+## Proposal
+
+Adopt the module layout described in `DOMAIN.md` (`core/`, `adapters/`, `cli/`, `web/`, `storage/`). Perform a sequence of focused pull requests:
+
+1. **Extract domain models to `core/`**  
+   Move data models and agent logic from `backend/app/models` and `backend/chatagent/agents`.  
+   _Proposed Issue: "Refactor: move models and agents to core" (medium impact: ~10 files)_
+
+2. **Isolate CLI into `cli/` package**  
+   Relocate `backend/chatagent/cli.py` and define an explicit entry point.  
+   _Proposed Issue: "Refactor: separate CLI module" (low impact: ~3 files)_
+
+3. **Split FastAPI web app into `web/`**  
+   Move `backend/chatagent/app.py`, templates, and static assets.  
+   _Proposed Issue: "Refactor: extract web module" (medium impact: ~8 files)_
+
+4. **Create `storage/` for persistence**  
+   Group `backend/chatagent/db` and `services/persistence.py` under a storage interface.  
+   _Proposed Issue: "Refactor: unify storage layer" (medium impact: ~6 files)_
+
+5. **Introduce adapters for external services**  
+   Relocate provider and tool implementations to `adapters/` while keeping abstract interfaces in `core/`.  
+   _Proposed Issue: "Refactor: migrate providers/tools to adapters" (high impact: ~12 files)_
+
+## Alternatives
+
+Continue with the flat structure. This risks tight coupling and harder testing as features grow.
+
+## Unresolved Questions
+
+- Exact package names may evolve.
+- Additional modules (e.g., `ui/`) could emerge as functionality grows.
+
+## References
+
+- [`docs/DOMAIN.md`](../DOMAIN.md)


### PR DESCRIPTION
## Summary
- document core entities and relationships in `docs/DOMAIN.md`
- propose modular boundaries and incremental refactor steps in `docs/rfcs/0001-module-boundaries.md`

## Motivation
Clarifies the chat simulator domain and outlines a path to a cleaner modular architecture.

## Related Issue
Refactor issues will be opened for each step outlined in RFC 0001 (unable to create automatically).

## Definition of Done
- [x] DOMAIN.md added
- [x] RFC 0001 added
- [ ] Follow-up issues created
- [ ] Tests added/updated (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68a12a65fc9c833380d6b8dd01bb48dd