### PR TITLE
feat: add config, logging, and error handling

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -42,3 +42,9 @@
 - `pytest` (fails: missing dependencies during collection)
 
 
+## Config, Logging, and Error Handling
+
+- Added `config.toml` and extended `Settings` to load from file and environment.
+- Implemented JSON structured logging with optional PII redaction.
+- Introduced centralized error handler with custom error types.
+- Added unit tests covering configuration loading, logging redaction, and error responses.

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -8,9 +8,14 @@ from typing import Any
 
 from jsonschema import Draft7Validator, RefResolver
 
-DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "schemas" / "simulation_config.schema.json"
+from chatagent.errors import ChatAgentError
 
-class ScenarioValidationError(Exception):
+DEFAULT_SCHEMA = (
+    Path(__file__).resolve().parents[1] / "schemas" / "simulation_config.schema.json"
+)
+
+
+class ScenarioValidationError(ChatAgentError):
     """Raised when a scenario file does not match the JSON schema."""
 
 
@@ -19,7 +24,9 @@ def load_schema(schema_path: Path = DEFAULT_SCHEMA) -> dict[str, Any]:
     return json.loads(schema_path.read_text())
 
 
-def validate_scenario(data: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) -> list[dict[str, str]]:
+def validate_scenario(
+    data: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA
+) -> list[dict[str, str]]:
     """Validate in-memory scenario data against the simulation schema.
 
     Args:

--- a/backend/chatagent/app.py
+++ b/backend/chatagent/app.py
@@ -1,24 +1,26 @@
 import asyncio
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from .agents import outer
-from .agents.inner import worker_loop
-from .db.core import init_db
 from app.services.validation import (
     ScenarioValidationError,
     validate_scenario,
     validate_scenario_file,
 )
+
+from .agents import outer
+from .agents.inner import worker_loop
+from .db.core import init_db
+from .errors import ChatAgentError
 from .providers.google import GoogleLLMClient
 from .services.llm import EchoLLMClient, LLMClient
 from .settings import settings
-
 
 app = FastAPI(title="ChatAgent MVP", version="0.1.0")
 app.add_middleware(
@@ -29,16 +31,26 @@ base_dir = Path(__file__).resolve().parent.parent / "app"
 templates = Jinja2Templates(directory=str(base_dir / "templates"))
 app.mount("/static", StaticFiles(directory=str(base_dir / "static")), name="static")
 
+logger = logging.getLogger(__name__)
+
 
 @app.on_event("startup")
 async def startup() -> None:
     init_db()
-    scenario_path = Path(__file__).resolve().parents[1] / "data" / "scenario_example.json"
+    scenario_path = (
+        Path(__file__).resolve().parents[1] / "data" / "scenario_example.json"
+    )
     try:
         validate_scenario_file(scenario_path)
     except ScenarioValidationError as exc:
         raise RuntimeError(f"Invalid scenario file: {exc}") from exc
     asyncio.create_task(worker_loop())
+
+
+@app.exception_handler(ChatAgentError)
+async def handle_chatagent_error(request: Request, exc: ChatAgentError) -> JSONResponse:
+    logger.error(str(exc))
+    return JSONResponse(status_code=400, content={"error": str(exc)})
 
 
 @app.get("/healthz")
@@ -59,12 +71,10 @@ async def ui(request: Request) -> HTMLResponse:
 router = APIRouter()
 
 
-
 def get_llm(model: str | None = None) -> LLMClient:
     if settings.llm_provider == "google":
         return GoogleLLMClient(model=model)
     return EchoLLMClient()
-
 
 
 @router.post("/chat")
@@ -77,10 +87,11 @@ async def chat(payload: dict) -> dict:
     return {"reply": reply}
 
 
-
 @router.get("/validate-scenario")
 async def validate_sample_scenario() -> dict:
-    scenario_path = Path(__file__).resolve().parents[1] / "data" / "scenario_example.json"
+    scenario_path = (
+        Path(__file__).resolve().parents[1] / "data" / "scenario_example.json"
+    )
     try:
         validate_scenario_file(scenario_path)
     except ScenarioValidationError as exc:

--- a/backend/chatagent/errors.py
+++ b/backend/chatagent/errors.py
@@ -1,0 +1,13 @@
+"""Custom error types for ChatAgent."""
+
+
+class ChatAgentError(Exception):
+    """Base error for ChatAgent."""
+
+
+class ConfigError(ChatAgentError):
+    """Raised when configuration is invalid."""
+
+
+class ProviderError(ChatAgentError):
+    """Raised when an LLM provider fails or is misconfigured."""

--- a/backend/chatagent/logging.py
+++ b/backend/chatagent/logging.py
@@ -1,0 +1,39 @@
+import json
+import logging
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        log_record: dict[str, Any] = {
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        return json.dumps(log_record)
+
+
+class PiiFilter(logging.Filter):
+    """Redact messages marked as PII when disabled."""
+
+    def __init__(self, show_pii: bool) -> None:
+        super().__init__()
+        self.show_pii = show_pii
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        if not self.show_pii and getattr(record, "pii", False):
+            record.msg = "[REDACTED]"
+        return True
+
+
+def setup_logging(level: str = "INFO", show_pii: bool = False) -> None:
+    """Configure root logger for structured JSON output."""
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(PiiFilter(show_pii))
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level.upper())

--- a/backend/chatagent/providers/google.py
+++ b/backend/chatagent/providers/google.py
@@ -1,7 +1,8 @@
 import httpx
 
-from ..settings import settings
+from ..errors import ProviderError
 from ..services.llm import LLMClient
+from ..settings import settings
 
 GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta"
 
@@ -12,6 +13,8 @@ class GoogleLLMClient(LLMClient):
     def __init__(self, model: str | None = None):
         self.model = model or settings.model_default
         self.api_key = settings.google_api_key
+        if not self.api_key:
+            raise ProviderError("Missing Google API key")
 
     async def predict(self, prompt: str) -> str:
         data = await self.chat([{"role": "user", "content": prompt}])

--- a/backend/chatagent/settings.py
+++ b/backend/chatagent/settings.py
@@ -1,5 +1,14 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import os
 from pathlib import Path
+
+from pydantic_settings import (
+    BaseSettings,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
+
+from .logging import setup_logging
+
 
 class Settings(BaseSettings):
     db: Path = Path("~/.chatagent/chatagent.sqlite3").expanduser()
@@ -9,6 +18,8 @@ class Settings(BaseSettings):
     llm_provider: str = "echo"
     host: str = "0.0.0.0"
     port: int = 8080
+    log_level: str = "INFO"
+    log_pii: bool = False
 
     model_config = SettingsConfigDict(
         env_prefix="CHATAGENT_",
@@ -16,6 +27,31 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
     )
 
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls,
+        init_settings,
+        env_settings,
+        dotenv_settings,
+        file_secret_settings,
+    ):
+        config_path = Path(
+            os.getenv(
+                "CHATAGENT_CONFIG_FILE",
+                Path(__file__).resolve().parent.parent / "config.toml",
+            )
+        )
+        return (
+            env_settings,
+            dotenv_settings,
+            TomlConfigSettingsSource(settings_cls, config_path),
+            init_settings,
+            file_secret_settings,
+        )
+
+
 settings = Settings()
 settings.workspace.mkdir(parents=True, exist_ok=True)
 settings.db.parent.mkdir(parents=True, exist_ok=True)
+setup_logging(settings.log_level, settings.log_pii)

--- a/backend/config.toml
+++ b/backend/config.toml
@@ -1,0 +1,11 @@
+# Default configuration for ChatAgent
+# Values can be overridden by environment variables prefixed with CHATAGENT_
+
+db = "~/.chatagent/chatagent.sqlite3"
+workspace = "~/sandbox/chatagent/projects"
+model_default = "gemini-1.5-flash"
+llm_provider = "echo"
+host = "0.0.0.0"
+port = 8080
+log_level = "INFO"
+log_pii = false

--- a/backend/tests/test_config_logging_error.py
+++ b/backend/tests/test_config_logging_error.py
@@ -1,0 +1,33 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from chatagent.app import app
+from chatagent.logging import setup_logging
+from chatagent.settings import Settings, settings
+
+
+def test_settings_from_file_and_env(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("host = '1.2.3.4'\nport = 9000\n")
+    monkeypatch.setenv("CHATAGENT_CONFIG_FILE", str(cfg))
+    monkeypatch.setenv("CHATAGENT_PORT", "1234")
+    s = Settings()
+    assert s.host == "1.2.3.4"
+    assert s.port == 1234
+
+
+def test_logging_redacts_pii(capsys):
+    setup_logging(level="INFO", show_pii=False)
+    logger = logging.getLogger("chatagent.test")
+    logger.info("secret", extra={"pii": True})
+    captured = capsys.readouterr()
+    assert "[REDACTED]" in captured.err
+
+
+def test_error_handler(monkeypatch):
+    monkeypatch.setattr(settings, "llm_provider", "google")
+    with TestClient(app) as client:
+        r = client.post("/api/chat", json={"project_id": 1, "text": "hi"})
+    assert r.status_code == 400
+    assert "Google API key" in r.json()["error"]


### PR DESCRIPTION
## Summary
- unify configuration via `config.toml` and environment using pydantic-settings
- add JSON structured logging with optional PII redaction
- centralize error handling with custom exceptions

## Testing
- `PYTHONPATH=. pytest tests/test_config_logging_error.py`

## Issue
- Related to #2

## Definition of Done
- [x] Config loads from env and config file
- [x] Structured logging with level control and PII redaction
- [x] Centralized error handler with custom error types
- [x] Unit tests added
- [x] REPORT.md updated

------
https://chatgpt.com/codex/tasks/task_e_68a12a7b21cc83339f2bf36383a46664