### PR TITLE
feat: add memory store and metrics

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -85,3 +85,8 @@ Added CodeQL analysis workflow for Python to run on pushes, pull requests, and w
 - Added `docs/DOMAIN.md` detailing core entities and relationships.
 - Drafted RFC `docs/rfcs/0001-module-boundaries.md` proposing incremental refactor steps toward a modular layout.
 
+
+## Memory and Metrics
+- Introduced in-memory conversation store with timestamp, speaker, content, and metadata.
+- Added metric computation for turns, average message length, and goal achievement via pluggable evaluator.
+- Covered basic flow with unit test simulating a short conversation.

--- a/backend/chatagent/memory/__init__.py
+++ b/backend/chatagent/memory/__init__.py
@@ -1,0 +1,10 @@
+from .store import MemoryItem, MemoryStore, InMemoryStore
+from .metrics import compute_metrics, Evaluator
+
+__all__ = [
+    "MemoryItem",
+    "MemoryStore",
+    "InMemoryStore",
+    "compute_metrics",
+    "Evaluator",
+]

--- a/backend/chatagent/memory/metrics.py
+++ b/backend/chatagent/memory/metrics.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable
+
+from .store import MemoryItem, MemoryStore
+
+
+Evaluator = Callable[[Iterable[MemoryItem]], bool]
+
+
+def compute_metrics(store: MemoryStore, evaluator: Evaluator) -> Dict[str, float | bool]:
+    """Calculate basic conversation metrics."""
+
+    messages = list(store.items())
+    turns = len(messages)
+    avg_length = (
+        sum(len(m.content) for m in messages) / turns if turns > 0 else 0.0
+    )
+    goal_reached = evaluator(messages)
+    return {"turns": turns, "avg_length": avg_length, "goal_reached": goal_reached}

--- a/backend/chatagent/memory/store.py
+++ b/backend/chatagent/memory/store.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class MemoryItem:
+    """Single conversation turn."""
+
+    timestamp: datetime
+    speaker: str
+    content: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class MemoryStore(ABC):
+    """Interface for conversation memory stores."""
+
+    @abstractmethod
+    def add(self, speaker: str, content: str, metadata: Dict[str, Any] | None = None) -> None:
+        """Persist a conversation turn."""
+
+    @abstractmethod
+    def items(self) -> Iterable[MemoryItem]:
+        """Return all stored conversation turns in order."""
+
+
+class InMemoryStore(MemoryStore):
+    """Simple in-memory implementation of :class:`MemoryStore`."""
+
+    def __init__(self) -> None:
+        self._items: List[MemoryItem] = []
+
+    def add(self, speaker: str, content: str, metadata: Dict[str, Any] | None = None) -> None:
+        self._items.append(
+            MemoryItem(
+                timestamp=datetime.utcnow(),
+                speaker=speaker,
+                content=content,
+                metadata=metadata or {},
+            )
+        )
+
+    def items(self) -> Iterable[MemoryItem]:
+        return list(self._items)

--- a/backend/tests/test_memory_metrics.py
+++ b/backend/tests/test_memory_metrics.py
@@ -1,0 +1,17 @@
+from chatagent.memory import InMemoryStore, compute_metrics
+
+
+def dummy_evaluator(messages):
+    return any("goal" in m.content.lower() for m in messages)
+
+
+def test_metrics_basic():
+    store = InMemoryStore()
+    store.add("user", "hello")
+    store.add("assistant", "hi there")
+    store.add("user", "goal accomplished")
+
+    metrics = compute_metrics(store, dummy_evaluator)
+    assert metrics["turns"] == 3
+    assert metrics["avg_length"] > 0
+    assert metrics["goal_reached"] is True


### PR DESCRIPTION
## Summary
- add in-memory conversation memory store
- compute basic conversation metrics (turns, avg length, goal)
- cover flow with unit test and update report

## Motivation
Enable tracking conversation history and evaluation metrics for simulations.

## Issue
Closes #31

## Testing
- no tests run

## Definition of Done
- [x] MemoryStore interface with in-memory default
- [x] Metrics: number of turns, average message length, goal attainment via evaluator
- [x] Mini-simulation unit test
- [x] REPORT.md updated


------
https://chatgpt.com/codex/tasks/task_e_68a12cff99488333bbf5baeec25f3a1e