### PR TITLE
feat: add LLM provider interface with mock and OpenAI skeleton

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -85,3 +85,15 @@ Added CodeQL analysis workflow for Python to run on pushes, pull requests, and w
 - Added `docs/DOMAIN.md` detailing core entities and relationships.
 - Drafted RFC `docs/rfcs/0001-module-boundaries.md` proposing incremental refactor steps toward a modular layout.
 
+# LLM Adapters
+
+## Summary
+- Introduced a pluggable `LLMProvider` interface and `MockLLM` for tests.
+- Added an `OpenAILLM` skeleton adapter loading its API key from `OPENAI_API_KEY`.
+- Expanded test suite with mock-based tests for the new adapters.
+
+## Testing
+- `python -m ruff check adapters tests/adapters`
+- `python -m black --check adapters tests/adapters`
+- `python -m pytest tests/adapters/test_llm.py`
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,3 +8,9 @@ If you discover a security issue, please report it responsibly.
 - Alternatively, open a private issue labeled "security".
 
 We will respond as soon as possible and work to address the issue promptly.
+
+## Secrets
+
+Do not commit API keys or other credentials to the repository. LLM adapters
+must read secrets such as `OPENAI_API_KEY` from environment variables or
+external secret managers.

--- a/backend/adapters/llm/__init__.py
+++ b/backend/adapters/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM adapter package."""
+
+from .mock import MockLLM  # noqa: F401
+from .openai import OpenAILLM  # noqa: F401
+from .provider import LLMProvider  # noqa: F401

--- a/backend/adapters/llm/mock.py
+++ b/backend/adapters/llm/mock.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .provider import LLMProvider
+
+
+class MockLLM(LLMProvider):
+    """Mock LLM provider used for tests."""
+
+    def __init__(self, response: str = "(mock)") -> None:
+        self.response = response
+
+    async def predict(self, prompt: str) -> str:  # pragma: no cover - trivial
+        return self.response

--- a/backend/adapters/llm/openai.py
+++ b/backend/adapters/llm/openai.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import os
+
+from .provider import LLMProvider
+
+
+class OpenAILLM(LLMProvider):
+    """Skeleton adapter for OpenAI's API."""
+
+    def __init__(self, model: str = "gpt-4o") -> None:
+        self.model = model
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise RuntimeError("Missing OpenAI API key")
+
+    async def predict(self, prompt: str) -> str:  # pragma: no cover - placeholder
+        raise NotImplementedError("OpenAI adapter not implemented")

--- a/backend/adapters/llm/provider.py
+++ b/backend/adapters/llm/provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class LLMProvider(ABC):
+    """Interface for large language model providers."""
+
+    @abstractmethod
+    async def predict(self, prompt: str) -> str:
+        """Return a completion for the given prompt."""
+        raise NotImplementedError

--- a/backend/tests/adapters/test_llm.py
+++ b/backend/tests/adapters/test_llm.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import pytest
+
+from adapters.llm import MockLLM, OpenAILLM
+
+
+def test_mock_llm_returns_response():
+    llm = MockLLM(response="hi")
+    assert asyncio.run(llm.predict("hello")) == "hi"
+
+
+def test_openai_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        OpenAILLM()
+
+
+def test_openai_predict_not_implemented(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    llm = OpenAILLM()
+    with pytest.raises(NotImplementedError):
+        asyncio.run(llm.predict("hello"))


### PR DESCRIPTION
## Summary
- introduce `LLMProvider` interface, `MockLLM` implementation, and skeleton `OpenAILLM` adapter loading its key from `OPENAI_API_KEY`
- document secret handling for adapters in `SECURITY.md`
- cover new adapters with unit tests and update project report

## Testing
- `python -m ruff check adapters tests/adapters`
- `python -m black --check adapters tests/adapters`
- `python -m pytest tests/adapters/test_llm.py`

## Related Issue
- Related to #35

## Definition of Done
- [x] LLMProvider interface and MockLLM
- [x] OpenAI adapter skeleton (env key)
- [x] tests with mock (no external API)
- [x] documentation update in SECURITY.md
- [x] report updated


------
https://chatgpt.com/codex/tasks/task_e_68a12d093afc8333a24d6bfb0c703223