### PR TITLE
feat: add scenario specification and parser

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -85,3 +85,9 @@ Added CodeQL analysis workflow for Python to run on pushes, pull requests, and w
 - Added `docs/DOMAIN.md` detailing core entities and relationships.
 - Drafted RFC `docs/rfcs/0001-module-boundaries.md` proposing incremental refactor steps toward a modular layout.
 
+## Scenario Specification and Parser
+
+- Defined simulation scenario format and JSON schema in `docs/SCENARIO_SPEC.md`.
+- Implemented Pydantic parser in `core/scenario` to load JSON or YAML files.
+- Added example scenarios and validation tests.
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tiktoken>=0.7",
     "faiss-cpu>=1.8.0.post1; platform_system!='Windows'",
     "jsonschema>=4.19",
+    "PyYAML>=6.0",
 ]
 [project.scripts]
 chatagent = "chatagent.cli:app"

--- a/backend/tests/test_scenario_parser.py
+++ b/backend/tests/test_scenario_parser.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from core.scenario import load_scenario, Scenario  # noqa: E402
+
+EXAMPLES = ROOT / "examples" / "scenarios"
+
+
+def test_load_valid_json() -> None:
+    scenario = load_scenario(EXAMPLES / "valid.json")
+    assert isinstance(scenario, Scenario)
+    assert len(scenario.agents) == 2
+
+
+def test_load_valid_yaml() -> None:
+    scenario = load_scenario(EXAMPLES / "valid.yaml")
+    assert scenario.roles[0].name == "user"
+
+
+def test_load_invalid() -> None:
+    with pytest.raises(ValidationError):
+        load_scenario(EXAMPLES / "invalid.json")

--- a/core/scenario/__init__.py
+++ b/core/scenario/__init__.py
@@ -1,0 +1,13 @@
+"""Scenario specification parser and models."""
+
+from .models import Agent, Role, Rule, Scenario, Tool
+from .parser import load_scenario
+
+__all__ = [
+    "Agent",
+    "Role",
+    "Rule",
+    "Scenario",
+    "Tool",
+    "load_scenario",
+]

--- a/core/scenario/models.py
+++ b/core/scenario/models.py
@@ -1,0 +1,46 @@
+"""Pydantic models describing scenario configuration."""
+
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class Role(BaseModel):
+    """Reusable role definition."""
+
+    name: str
+    description: str | None = None
+
+
+class Tool(BaseModel):
+    """Tool available within the simulation."""
+
+    name: str
+    description: str | None = None
+
+
+class Rule(BaseModel):
+    """Simple rule described by trigger and resulting action."""
+
+    trigger: str
+    action: str
+
+
+class Agent(BaseModel):
+    """Agent participating in the scenario."""
+
+    id: str
+    name: str
+    role: str
+    goals: List[str] = Field(default_factory=list)
+
+
+class Scenario(BaseModel):
+    """Top level scenario configuration."""
+
+    description: str
+    roles: List[Role] = Field(default_factory=list)
+    tools: List[Tool] = Field(default_factory=list)
+    agents: List[Agent]
+    rules: List[Rule] = Field(default_factory=list)

--- a/core/scenario/parser.py
+++ b/core/scenario/parser.py
@@ -1,0 +1,22 @@
+"""Parser utilities for scenario files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import Scenario
+
+
+def load_scenario(path: Path) -> Scenario:
+    """Load and validate a scenario from a JSON or YAML file."""
+
+    raw = path.read_text()
+    if path.suffix in {".yaml", ".yml"}:
+        data: Any = yaml.safe_load(raw)
+    else:
+        data = json.loads(raw)
+    return Scenario.model_validate(data)

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -1,0 +1,6 @@
+# Report
+
+## Decisions
+- Defined scenario DSL with roles, tools, agents, and rules.
+- Implemented Pydantic parser under `core.scenario`.
+- Added example JSON/YAML scenarios and unit tests.

--- a/docs/SCENARIO_SPEC.md
+++ b/docs/SCENARIO_SPEC.md
@@ -1,0 +1,114 @@
+# Scenario Specification
+
+This document defines the JSON/YAML format for simulation scenarios. Each
+scenario lists participating agents, their roles and goals, optional tools
+available to the simulation, and high level interaction rules.
+
+## Structure
+
+```yaml
+# High level description of the scenario
+description: Demo scenario
+
+# Optional reusable role definitions
+roles:
+  - name: user
+    description: Human participant
+  - name: assistant
+    description: Helpful AI assistant
+
+# Tools available to agents during the simulation
+tools:
+  - name: search
+    description: Query external information
+
+# Agents taking part in the scenario
+agents:
+  - id: a1
+    name: Alice
+    role: user
+    goals:
+      - greet everyone
+  - id: a2
+    name: Bot
+    role: assistant
+
+# Rules influencing the flow of the simulation
+rules:
+  - trigger: greet
+    action: reply_greeting
+```
+
+## JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Scenario",
+  "type": "object",
+  "properties": {
+    "description": {"type": "string"},
+    "roles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "description": {"type": "string"}
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "description": {"type": "string"}
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "role": {"type": "string"},
+          "goals": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": []
+          }
+        },
+        "required": ["id", "name", "role"],
+        "additionalProperties": false
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "trigger": {"type": "string"},
+          "action": {"type": "string"}
+        },
+        "required": ["trigger", "action"],
+        "additionalProperties": false
+      },
+      "default": []
+    }
+  },
+  "required": ["description", "agents"],
+  "additionalProperties": false
+}
+```
+
+Example scenarios can be found under `examples/scenarios/`.

--- a/examples/scenarios/invalid.json
+++ b/examples/scenarios/invalid.json
@@ -1,0 +1,7 @@
+{
+  "description": "Broken scenario",
+  "agents": [
+    {"id": "a1", "name": "Alice", "role": "user"},
+    {"id": "a2", "name": "Bot", "goals": ["assist"]}
+  ]
+}

--- a/examples/scenarios/valid.json
+++ b/examples/scenarios/valid.json
@@ -1,0 +1,17 @@
+{
+  "description": "Demo scenario",
+  "roles": [
+    {"name": "user", "description": "Human participant"},
+    {"name": "assistant", "description": "Helpful AI assistant"}
+  ],
+  "tools": [
+    {"name": "search", "description": "Query external information"}
+  ],
+  "agents": [
+    {"id": "a1", "name": "Alice", "role": "user", "goals": ["greet everyone"]},
+    {"id": "a2", "name": "Bot", "role": "assistant"}
+  ],
+  "rules": [
+    {"trigger": "greet", "action": "reply_greeting"}
+  ]
+}

--- a/examples/scenarios/valid.yaml
+++ b/examples/scenarios/valid.yaml
@@ -1,0 +1,21 @@
+description: Demo scenario
+roles:
+  - name: user
+    description: Human participant
+  - name: assistant
+    description: Helpful AI assistant
+tools:
+  - name: search
+    description: Query external information
+agents:
+  - id: a1
+    name: Alice
+    role: user
+    goals:
+      - greet everyone
+  - id: a2
+    name: Bot
+    role: assistant
+rules:
+  - trigger: greet
+    action: reply_greeting


### PR DESCRIPTION
## Summary
- define scenario DSL with roles, tools, agents and rules
- implement pydantic parser that reads JSON/YAML
- add examples and validation tests

## Motivation
Provide a structured format for defining simulations and validating scenarios.

## Related Issue
Closes #23

## Definition of Done
- [x] Scenario specification document with schema
- [x] Parser and models under `core.scenario`
- [x] Example scenarios
- [x] Unit tests for valid and invalid scenarios

## Testing
- `python -m ruff check backend core`
- `python -m black --check backend core`
- `cd backend && python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12cf1b18483338f7ca79eca4528e0