### PR TITLE
feat: add CLI tool for running simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ chatagent serve
 # open http://localhost:8080
 ```
 
+## Usage
+
+Run simulations without the web UI:
+
+```bash
+chatsim run --scenario backend/data/scenario_example.json
+```
+
+Add `--report` to also generate a Markdown report under `reports/`.
+
 ## Docker
 
 Build and run the API in a container:

--- a/REPORT.md
+++ b/REPORT.md
@@ -85,3 +85,8 @@ Added CodeQL analysis workflow for Python to run on pushes, pull requests, and w
 - Added `docs/DOMAIN.md` detailing core entities and relationships.
 - Drafted RFC `docs/rfcs/0001-module-boundaries.md` proposing incremental refactor steps toward a modular layout.
 
+## CLI Tool
+
+- Introduced a `chatsim` command to run scenarios from the CLI and emit NDJSON logs.
+- Implemented optional `--report` flag to generate Markdown summaries in `reports/`.
+

--- a/backend/chatagent/sim_cli.py
+++ b/backend/chatagent/sim_cli.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+import typer
+
+from app.models import SimulationConfig
+from app.services.scheduler import Scheduler
+from app.services.validation import validate_scenario_file
+from app.services.world import Event as WorldEvent, World
+
+app = typer.Typer(help="Run chat simulations without the web UI")
+
+
+@app.callback()
+def main() -> None:
+    """CLI entry point."""
+
+
+@app.command()
+def run(
+    scenario: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to scenario JSON"),
+    report: bool = typer.Option(False, '--report', help="Write Markdown report to /reports"),
+) -> None:
+    """Run a simulation from SCENARIO and emit NDJSON logs."""
+    try:
+        validate_scenario_file(scenario)
+    except Exception as exc:  # pragma: no cover - validation errors are simple to reproduce
+        typer.echo(json.dumps({"error": str(exc)}))
+        raise typer.Exit(1)
+
+    config = SimulationConfig.model_validate_json(scenario.read_text())
+
+    world = World()
+    scheduler = Scheduler(world)
+
+    for event in config.events:
+        params = event.intent.parameters or {}
+        world_event = WorldEvent(
+            event.intent.name,
+            amount=params.get("amount"),
+            max_value=params.get("max_value"),
+        )
+        scheduler.schedule(event.timestamp, world_event)
+
+    records = []
+    while scheduler.queue:
+        triggered = scheduler.tick()
+        snapshot = world.snapshot()
+        for triggered_event in triggered:
+            record = {
+                "time": scheduler.time,
+                "event": triggered_event.__dict__,
+                "world": snapshot.__dict__,
+            }
+            records.append(record)
+            typer.echo(json.dumps(record))
+
+    if report:
+        report_dir = Path("reports")
+        report_dir.mkdir(exist_ok=True)
+        report_path = report_dir / f"{scenario.stem}.md"
+        report_path.write_text(
+            "# Simulation Report\n\n" f"Scenario: {scenario.name}\n\n" f"Final counter: {world.snapshot().counter}\n"
+        )
+
+
+if __name__ == "__main__":
+    app()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 ]
 [project.scripts]
 chatagent = "chatagent.cli:app"
+chatsim = "chatagent.sim_cli:app"
 
 [project.optional-dependencies]
 dev = [

--- a/backend/tests/test_cli_run.py
+++ b/backend/tests/test_cli_run.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_run(tmp_path: Path) -> None:
+    scenario = {
+        "world": {
+            "description": "demo",
+            "agents": [{"id": "a1", "name": "A", "role": "user"}],
+        },
+        "events": [
+            {
+                "timestamp": 0,
+                "agent_id": "a1",
+                "intent": {"name": "inc", "parameters": {"amount": 2}},
+            }
+        ],
+    }
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(json.dumps(scenario))
+
+    cmd = [sys.executable, "-m", "chatagent.sim_cli", "run", "--scenario", str(scenario_path)]
+    env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+    lines = res.stdout.strip().splitlines()
+    assert lines
+    record = json.loads(lines[-1])
+    assert record["world"]["counter"] == 2
+
+
+def test_cli_report(tmp_path: Path) -> None:
+    scenario = {
+        "world": {
+            "description": "demo",
+            "agents": [{"id": "a1", "name": "A", "role": "user"}],
+        },
+        "events": [
+            {
+                "timestamp": 0,
+                "agent_id": "a1",
+                "intent": {"name": "inc", "parameters": {"amount": 1}},
+            }
+        ],
+    }
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(json.dumps(scenario))
+    cmd = [
+        sys.executable,
+        "-m",
+        "chatagent.sim_cli",
+        "run",
+        "--scenario",
+        str(scenario_path),
+        "--report",
+    ]
+    env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(cmd, capture_output=True, text=True, check=True, cwd=tmp_path, env=env)
+    report_path = tmp_path / "reports" / "scenario.md"
+    assert report_path.exists()


### PR DESCRIPTION
## Summary
- add `chatsim` CLI to run scenarios and optionally generate reports
- document CLI usage in README
- cover CLI with tests

## Motivation
Enable running simulations in CI without the web UI.

## References
- Related to #1

## Definition of Done
- [x] CLI runs scenarios and outputs NDJSON
- [x] `--report` writes a Markdown summary
- [x] Usage documented in README
- [x] Tests added

## Testing
- `make lint` *(fails: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section)*
- `make test`
- `python -m chatagent.sim_cli run --scenario backend/data/scenario_example.json --report`


------
https://chatgpt.com/codex/tasks/task_e_68a12d034b8c8333bf7ab132992515b8