### PR TITLE
docs: add API reference and architecture diagrams

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocstrings[python]
       - run: mkdocs build --strict

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,3 +17,12 @@ A deterministic mode seeds the scheduler's random number generator so that
 stochastic events produce reproducible results. Tests can replay the same
 sequence of events by constructing a scheduler with the same seed and feeding it
 the same events.
+
+## Scheduler Flow
+
+```mermaid
+flowchart LR
+    Start -->|tick| Advance[Advance Time]
+    Advance --> Process[Process Events]
+    Process --> Update[Update World]
+```

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,5 @@
+# Report
+
+- Added mermaid diagrams to architecture documentation.
+- Introduced mkdocstrings-based API reference.
+- Updated documentation build to generate API docs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,14 @@
 
 The system will consist of a FastAPI backend exposing REST and WebSocket interfaces, a scheduler driving agent simulations, and optional web and CLI frontends.
 
+```mermaid
+graph TD
+    C[Client] --> A[API Service]
+    A --> S[Scheduler]
+    S --> D[Agents]
+    S --> P[Persistence]
+```
+
 ## Components
 
 - **API Service**: Handles HTTP requests, WebSocket connections, and scenario validation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: chatagent

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,0 @@
-# Architecture
-
-An overview of ChatAgent components and data flow.
-
-For a detailed description see [ARCHITECTURE.md](../ARCHITECTURE.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,23 @@
 site_name: ChatAgent
 theme:
   name: material
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [backend]
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
 nav:
   - Quickstart: quickstart.md
-  - Architecture: architecture.md
+  - Architecture: ARCHITECTURE.md
+  - API Reference: api.md
   - Contributing: contributing.md
   - Changelog: changelog.md
   - Project Vision: project-vision.md


### PR DESCRIPTION
## Summary
- add mkdocstrings-generated API reference
- include mermaid diagrams in architecture docs
- build docs with mkdocstrings in CI

## Motivation
- clarify project structure and surface API documentation

## Related Issues
- Related to #4

## Definition of Done
- [x] API reference generated via CI
- [x] Mermaid architecture diagrams in docs
- [x] Docs site references new pages
- [ ] Tests updated or added

## Testing
- `ruff check backend core` (fails: import order, line length)
- `PYTHONPATH=backend pytest backend/tests`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68a12f40735c8333a177b03aef0f2a18