### PR TITLE
feat: add example scenarios and quick demo

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,0 +1,32 @@
+name: examples-smoke
+
+on:
+  push:
+    paths:
+      - 'examples/**'
+      - '.github/workflows/examples-smoke.yml'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - '.github/workflows/examples-smoke.yml'
+
+jobs:
+  run-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install backend
+        run: |
+          cd backend
+          pip install -e .
+      - name: Run quick demo
+        run: |
+          bash examples/quick_demo.sh
+      - name: Run scenarios
+        run: |
+          chatsim run --scenario examples/simple.json
+          chatsim run --scenario examples/multi_agents.json
+          chatsim run --scenario examples/evaluator.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ chatagent serve
 # open http://localhost:8080
 ```
 
+Run a quick demo using the mock LLM and a sample scenario:
+
+```bash
+bash examples/quick_demo.sh
+```
+
 ## Usage
 
 Run simulations without the web UI:

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,8 @@
+# Report
+
+## Summary
+
+- Added example scenarios demonstrating simple, multi-agent, and evaluator setups.
+- Introduced a quick demo script using the mock LLM.
+- Documented the demo in the README and quickstart guide.
+- Added CI workflow to run examples and demo.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,4 +17,10 @@ echo 'CHATAGENT_GOOGLE_API_KEY=YOUR_KEY' > .env
 chatagent serve
 ```
 
+3. See a quick demo using the mock LLM:
+
+```bash
+bash examples/quick_demo.sh
+```
+
 This page is a placeholder for a more detailed guide.

--- a/examples/evaluator.json
+++ b/examples/evaluator.json
@@ -1,0 +1,36 @@
+{
+  "world": {
+    "description": "Conversation with evaluator",
+    "agents": [
+      {"id": "u1", "name": "User", "role": "user"},
+      {"id": "b1", "name": "Bot", "role": "assistant"},
+      {"id": "e1", "name": "Judge", "role": "evaluator"}
+    ]
+  },
+  "events": [
+    {
+      "timestamp": 0,
+      "agent_id": "u1",
+      "intent": {
+        "name": "inc",
+        "parameters": {"amount": 1}
+      }
+    },
+    {
+      "timestamp": 1,
+      "agent_id": "b1",
+      "intent": {
+        "name": "inc",
+        "parameters": {"amount": 2}
+      }
+    },
+    {
+      "timestamp": 2,
+      "agent_id": "e1",
+      "intent": {
+        "name": "rand",
+        "parameters": {"max_value": 1}
+      }
+    }
+  ]
+}

--- a/examples/multi_agents.json
+++ b/examples/multi_agents.json
@@ -1,0 +1,27 @@
+{
+  "world": {
+    "description": "Two agents interacting",
+    "agents": [
+      {"id": "u1", "name": "User", "role": "user"},
+      {"id": "b1", "name": "Bot", "role": "assistant"}
+    ]
+  },
+  "events": [
+    {
+      "timestamp": 0,
+      "agent_id": "u1",
+      "intent": {
+        "name": "inc",
+        "parameters": {"amount": 1}
+      }
+    },
+    {
+      "timestamp": 1,
+      "agent_id": "b1",
+      "intent": {
+        "name": "inc",
+        "parameters": {"amount": 2}
+      }
+    }
+  ]
+}

--- a/examples/quick_demo.py
+++ b/examples/quick_demo.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from adapters.llm import MockLLM
+from chatagent.agents.outer import handle_user_input
+
+
+async def main() -> None:
+    """Run a minimal demo using the mock LLM."""
+    llm = MockLLM(response="Hello from mock")
+    reply = await handle_user_input(project_id=1, user_text="hi", llm=llm)
+    print(f"Agent replied: {reply}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/quick_demo.sh
+++ b/examples/quick_demo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Run a minimal demo using the mock LLM and a simple scenario.
+set -e
+python examples/quick_demo.py
+chatsim run --scenario examples/simple.json >/dev/null

--- a/examples/simple.json
+++ b/examples/simple.json
@@ -1,0 +1,18 @@
+{
+  "world": {
+    "description": "Single agent saying hello",
+    "agents": [
+      {"id": "u1", "name": "User", "role": "user"}
+    ]
+  },
+  "events": [
+    {
+      "timestamp": 0,
+      "agent_id": "u1",
+      "intent": {
+        "name": "inc",
+        "parameters": {"amount": 1}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add simple, multi-agent, and evaluator scenarios
- provide quick demo script documented in README and quickstart
- exercise examples in new examples-smoke workflow

## Motivation
Showcase how to run the project with runnable examples and a mock agent.

Closes #4

## Definition of Done
- [ ] Examples run in CI
- [ ] Quickstart includes up-to-date demo instructions
- [ ] Report updated


------
https://chatgpt.com/codex/tasks/task_e_68a12f394e58833399bd763622420a1e