### PR TITLE
feat: add installation and update scripts

### DIFF
--- a/docs/REPORT-install-scripts.md
+++ b/docs/REPORT-install-scripts.md
@@ -1,0 +1,6 @@
+# Report: Installation and Update Scripts
+
+## Summary
+- Installation script now checks for missing OS packages, installs only what's absent, and reports clear errors.
+- Update script validates existing installation and virtual environment before pulling and reinstalling the package.
+- Both scripts disable interactive git credential prompts and allow overriding the repository URL.

--- a/scripts/install_chatagent.sh
+++ b/scripts/install_chatagent.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'echo "[ERROR] Installation failed on line $LINENO" >&2' ERR
+
+# Default installation directory and repository URL
+INSTALL_DIR="${1:-$HOME/chatagent}"
+REPO_URL="${2:-https://github.com/OWNER/REPO.git}"
+
+# Determine whether sudo is needed
+if command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+required_packages=(git python3 python3-venv python3-pip build-essential)
+missing_packages=()
+for pkg in "${required_packages[@]}"; do
+  dpkg -s "$pkg" >/dev/null 2>&1 || missing_packages+=("$pkg")
+done
+
+if [ ${#missing_packages[@]} -ne 0 ]; then
+  echo "Installing missing packages: ${missing_packages[*]}"
+  $SUDO apt-get update || { echo "[ERROR] apt-get update failed" >&2; exit 1; }
+  $SUDO apt-get install -y "${missing_packages[@]}" || { echo "[ERROR] package installation failed" >&2; exit 1; }
+else
+  echo "All required packages already installed."
+fi
+
+# Clone repository if not already present
+if [ ! -d "$INSTALL_DIR/.git" ]; then
+  GIT_TERMINAL_PROMPT=0 git clone "$REPO_URL" "$INSTALL_DIR" || { echo "[ERROR] git clone failed for $REPO_URL" >&2; exit 1; }
+else
+  echo "Repository already present at $INSTALL_DIR, skipping clone."
+fi
+
+# Set up virtual environment and install package
+cd "$INSTALL_DIR/backend" || { echo "[ERROR] backend directory missing" >&2; exit 1; }
+if [ ! -d .venv ]; then
+  python3 -m venv .venv || { echo "[ERROR] virtual environment creation failed" >&2; exit 1; }
+fi
+source .venv/bin/activate || { echo "[ERROR] failed to activate virtual environment" >&2; exit 1; }
+pip install -e . || { echo "[ERROR] pip install failed" >&2; exit 1; }
+
+echo "ChatAgent installed in $INSTALL_DIR"

--- a/scripts/update_chatagent.sh
+++ b/scripts/update_chatagent.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'echo "[ERROR] Update failed on line $LINENO" >&2' ERR
+
+# Default installation directory
+INSTALL_DIR="${1:-$HOME/chatagent}"
+
+if [ ! -d "$INSTALL_DIR/.git" ]; then
+  echo "[ERROR] ChatAgent is not installed in $INSTALL_DIR" >&2
+  exit 1
+fi
+
+cd "$INSTALL_DIR" || { echo "[ERROR] cannot access $INSTALL_DIR" >&2; exit 1; }
+GIT_TERMINAL_PROMPT=0 git pull || { echo "[ERROR] git pull failed" >&2; exit 1; }
+
+if [ ! -d backend/.venv ]; then
+  echo "[ERROR] virtual environment not found; run install_chatagent.sh first" >&2
+  exit 1
+fi
+
+cd backend || { echo "[ERROR] backend directory missing" >&2; exit 1; }
+source .venv/bin/activate || { echo "[ERROR] failed to activate virtual environment" >&2; exit 1; }
+pip install -e . || { echo "[ERROR] pip install failed" >&2; exit 1; }
+
+echo "ChatAgent updated in $INSTALL_DIR"


### PR DESCRIPTION
## Summary
- harden install_chatagent.sh with repository parameter and non-interactive git clone
- prevent credential prompts in update_chatagent.sh
- document non-interactive git behavior

## Motivation
Public clones of the repository should not prompt for credentials; scripts now fail fast when authentication is required.

## Related Issue
- #123

## Testing
- `make lint` *(fails: 14 files would be reformatted)*
- `make test` *(fails: ModuleNotFoundError: No module named 'jsonschema`)*

## Definition of Done
- [x] Installation script added
- [x] Update script added
- [x] Report documented
- [ ] Tests pass


------
https://chatgpt.com/codex/tasks/task_e_68a1325c2f4083338f8ab25d7d1faec5