### PR TITLE
fix: validate repo URL in install scripts

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -6,3 +6,8 @@ Introduced configuration options to improve testability and responsiveness:
 - Added `db_in_memory` setting to allow using an in-memory SQLite database, useful for tests and ephemeral environments.
 - Updated database initialization to respect the new in-memory option.
 - Enabled previously skipped tests that now run against the in-memory database.
+
+## Fix repository URL in install scripts
+
+- Added validation and configurable repository URL to `scripts/install_chatagent.sh` and `scripts/update_chatagent.sh` to prevent cloning the GitHub root when repository parameters are missing.
+

--- a/scripts/install_chatagent.sh
+++ b/scripts/install_chatagent.sh
@@ -6,6 +6,15 @@ trap 'echo "[ERROR] Installation failed on line $LINENO" >&2' ERR
 # Default installation directory
 INSTALL_DIR="${1:-$HOME/chatagent}"
 
+# Repository to clone (can be overridden by second argument)
+REPO_URL="${2:-https://github.com/OWNER/REPO.git}"
+
+# Validate repository URL to avoid cloning the GitHub root
+if [[ ! "$REPO_URL" =~ ^https://github\.com/.+/.+\.git$ ]]; then
+  echo "[ERROR] Invalid repository URL: $REPO_URL" >&2
+  exit 1
+fi
+
 # Determine whether sudo is needed
 if command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
@@ -29,7 +38,7 @@ fi
 
 # Clone repository if not already present
 if [ ! -d "$INSTALL_DIR/.git" ]; then
-  git clone https://github.com/OWNER/REPO.git "$INSTALL_DIR" || { echo "[ERROR] git clone failed" >&2; exit 1; }
+  git clone "$REPO_URL" "$INSTALL_DIR" || { echo "[ERROR] git clone failed" >&2; exit 1; }
 else
   echo "Repository already present at $INSTALL_DIR, skipping clone."
 fi

--- a/scripts/update_chatagent.sh
+++ b/scripts/update_chatagent.sh
@@ -6,12 +6,27 @@ trap 'echo "[ERROR] Update failed on line $LINENO" >&2' ERR
 # Default installation directory
 INSTALL_DIR="${1:-$HOME/chatagent}"
 
+# Optional repository URL to ensure correct remote
+REPO_URL="${2:-}"
+
+if [[ -n "$REPO_URL" ]]; then
+  if [[ ! "$REPO_URL" =~ ^https://github\.com/.+/.+\.git$ ]]; then
+    echo "[ERROR] Invalid repository URL: $REPO_URL" >&2
+    exit 1
+  fi
+fi
+
 if [ ! -d "$INSTALL_DIR/.git" ]; then
   echo "[ERROR] ChatAgent is not installed in $INSTALL_DIR" >&2
   exit 1
 fi
 
 cd "$INSTALL_DIR" || { echo "[ERROR] cannot access $INSTALL_DIR" >&2; exit 1; }
+
+if [[ -n "$REPO_URL" ]]; then
+  git remote set-url origin "$REPO_URL" || { echo "[ERROR] failed to set remote URL" >&2; exit 1; }
+fi
+
 git pull || { echo "[ERROR] git pull failed" >&2; exit 1; }
 
 if [ ! -d backend/.venv ]; then


### PR DESCRIPTION
## Summary
- validate and parameterize repository URL in install/update scripts
- document installation script update in REPORT.md

## Motivation
- prevent installers from cloning the GitHub root and prompting for credentials

## Related Issue
- Closes #1

## Testing
- `shellcheck scripts/install_chatagent.sh scripts/update_chatagent.sh`
- `bash -n scripts/install_chatagent.sh scripts/update_chatagent.sh`

## Definition of Done
- [x] install script validates repo URL
- [x] update script accepts optional repo URL
- [x] documentation updated
- [x] tests executed

------
https://chatgpt.com/codex/tasks/task_e_68a1374ed5bc83338a37df6dd43adaf7