### PR TITLE
feat: add run script and auto start after install

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -11,3 +11,9 @@ Introduced configuration options to improve testability and responsiveness:
 
 - Added validation and configurable repository URL to `scripts/install_chatagent.sh` and `scripts/update_chatagent.sh` to prevent cloning the GitHub root when repository parameters are missing.
 
+## Auto-run ChatAgent after installation
+
+- Default repository URL in scripts now uses the full HTTPS link.
+- Added `scripts/run_chatagent.sh` to set up a virtual environment and start the server.
+- `scripts/install_chatagent.sh` now invokes the new run script after cloning to launch the application immediately.
+

--- a/scripts/install_chatagent.sh
+++ b/scripts/install_chatagent.sh
@@ -2,22 +2,15 @@
 set -Eeuo pipefail
 
 # === Nastavení ===
-# Repo můžeš přepsat env proměnnou CHATAGENT_REPO (formát owner/repo nebo plná URL)
-# Př.: CHATAGENT_REPO="procmadatelzobak/chatagent"
-REPO_INPUT="${CHATAGENT_REPO:-procmadatelzobak/chatagent}"
+# Repo můžeš přepsat env proměnnou CHATAGENT_REPO (plná URL)
+# Př.: CHATAGENT_REPO="https://github.com/procmadatelzobak/chatagent.git"
+REPO_INPUT="${CHATAGENT_REPO:-https://github.com/procmadatelzobak/chatagent.git}"
 BRANCH="${CHATAGENT_BRANCH:-main}"
 TARGET_DIR="${CHATAGENT_DIR:-$HOME/chatagent}"
 
 # === Normalizace URL na HTTPS bez přihlašování ===
-if [[ "$REPO_INPUT" =~ ^https?:// ]]; then
-  # plná URL -> očistit o trailing slash a doplnit .git, pokud chybí
-  REPO_URL="${REPO_INPUT%/}"
-  [[ "$REPO_URL" != *.git ]] && REPO_URL="${REPO_URL}.git"
-else
-  # owner/repo -> složit na https
-  REPO_URL="https://github.com/${REPO_INPUT%/}"
-  [[ "$REPO_URL" != *.git ]] && REPO_URL="${REPO_URL}.git"
-fi
+REPO_URL="${REPO_INPUT%/}"
+[[ "$REPO_URL" != *.git ]] && REPO_URL="${REPO_URL}.git"
 
 export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/true
@@ -74,4 +67,5 @@ else
   fi
 fi
 
-echo "✅ Hotovo."
+echo "✅ Instalace dokončena, spouštím ChatAgent…"
+"$TARGET_DIR/scripts/run_chatagent.sh" "$TARGET_DIR"

--- a/scripts/run_chatagent.sh
+++ b/scripts/run_chatagent.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${1:-$HOME/chatagent}"
+
+if [ ! -d "$INSTALL_DIR/backend" ]; then
+  echo "[ERROR] ChatAgent is not installed in $INSTALL_DIR" >&2
+  exit 1
+fi
+
+cd "$INSTALL_DIR/backend"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -e .
+else
+  source .venv/bin/activate
+fi
+
+chatagent serve

--- a/scripts/update_chatagent.sh
+++ b/scripts/update_chatagent.sh
@@ -7,7 +7,7 @@ trap 'echo "[ERROR] Update failed on line $LINENO" >&2' ERR
 INSTALL_DIR="${1:-$HOME/chatagent}"
 
 # Optional repository URL to ensure correct remote
-REPO_URL="${2:-}"
+REPO_URL="${2:-https://github.com/procmadatelzobak/chatagent.git}"
 
 if [[ -n "$REPO_URL" ]]; then
   if [[ ! "$REPO_URL" =~ ^https://github\.com/.+/.+\.git$ ]]; then


### PR DESCRIPTION
## Summary
- add `scripts/run_chatagent.sh` to set up venv and serve the app
- run the app after cloning in `scripts/install_chatagent.sh`
- default repository URL in scripts set to the full HTTPS link

## Motivation
- simplify starting ChatAgent right after installation
- avoid cloning the wrong repository

## Related Issue
- resolves #1

## Definition of Done
- [x] run script added
- [x] install script launches application
- [x] repository URL replaced in scripts
- [ ] tests passing

## Testing
- `pytest` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68a13c5167b88333878f129cc7d67115