### PR TITLE
fix: remove duplicate include in pyproject

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,6 +52,5 @@ select = ["E", "F", "I"]
 
 [tool.setuptools.packages.find]
 # Include the lightweight adapter utilities so tests can import them.
-include = ["app*", "chatagent*", "adapters*"]
 include = ["chatagent", "app*", "adapters*"]
 exclude = ["data*", "systemd*", "tests*"]


### PR DESCRIPTION
## Summary
- fix editable install by deduplicating package include configuration

## Testing
- `ruff check backend`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a1d40a85408333a9eb04e954d5611a